### PR TITLE
feat(nav): add supporting code and failing tests for sample (#366)

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,7 +14,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.54.2
           args: --verbose
 
   test:

--- a/xfs/nav/directory-entries.go
+++ b/xfs/nav/directory-entries.go
@@ -1,6 +1,7 @@
 package nav
 
 import (
+	"fmt"
 	"io/fs"
 
 	"github.com/samber/lo"
@@ -24,7 +25,7 @@ type directoryEntriesFactory struct{}
 type directoryEntriesFactoryParams struct {
 	o       *TraverseOptions
 	order   DirectoryEntryOrderEnum
-	entries *[]fs.DirEntry
+	entries []fs.DirEntry
 }
 
 func (directoryEntriesFactory) new(params *directoryEntriesFactoryParams) *DirectoryEntries {
@@ -46,8 +47,13 @@ type DirectoryEntries struct {
 	Files   []fs.DirEntry
 }
 
-func (e *DirectoryEntries) arrange(entries *[]fs.DirEntry) {
-	grouped := lo.GroupBy(*entries, func(item fs.DirEntry) bool {
+func (e *DirectoryEntries) Sample() *DirectoryEntries {
+	fmt.Println("❌❌❌ DirectoryEntries.Sample NOT-IMPLEMENTED")
+	return e
+}
+
+func (e *DirectoryEntries) arrange(entries []fs.DirEntry) {
+	grouped := lo.GroupBy(entries, func(item fs.DirEntry) bool {
 		return item.IsDir()
 	})
 
@@ -76,8 +82,8 @@ func (e *DirectoryEntries) all() []fs.DirEntry {
 	return result
 }
 
-func (e *DirectoryEntries) sort(entries *[]fs.DirEntry) {
-	if err := e.Options.Hooks.Sort(*entries); err != nil {
+func (e *DirectoryEntries) sort(entries []fs.DirEntry) {
+	if err := e.Options.Hooks.Sort(entries); err != nil {
 		panic(xi18n.NewSortFnFailedError())
 	}
 }

--- a/xfs/nav/errors.go
+++ b/xfs/nav/errors.go
@@ -1,8 +1,13 @@
 package nav
 
 import (
+	"errors"
 	"fmt"
 )
+
+// Errors defined here are internal errors that are of no value to end
+// users (hence not l10n). There are usually programming errors which
+// means they only have meaning for client developers.
 
 // ❌ Invalid Notification Mute Requested
 
@@ -51,3 +56,11 @@ func NewInvalidPeriscopeRootPathNativeError(root, current string) error {
 func NewResumeControllerNotSetNativeError(from string) error {
 	return fmt.Errorf("internal: resume controller not set (from: '%v')", from)
 }
+
+// static errors, identifiable with errors.Is
+
+// ErrUndefinedSubscriptionType indicates client has not set the navigation
+// subscription type at /Options.Store.Subscription.
+var ErrUndefinedSubscriptionType = errors.New(
+	"undefined subscription type; please set in traverse options (/Options.Store.Subscription)",
+)

--- a/xfs/nav/filter-defs.go
+++ b/xfs/nav/filter-defs.go
@@ -167,3 +167,10 @@ type compoundCounters struct {
 	filteredIn  uint
 	filteredOut uint
 }
+
+var BenignNodeFilterDef = FilterDef{
+	Type:        FilterTypeRegexEn,
+	Description: "benign allow all",
+	Pattern:     ".",
+	Scope:       ScopeRootEn,
+}

--- a/xfs/nav/filter-glob_test.go
+++ b/xfs/nav/filter-glob_test.go
@@ -114,7 +114,7 @@ var _ = Describe("FilterGlob", Ordered, func() {
 				message:      "universal(any scope): glob filter",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeAny,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   8,
 					folders: 0,
 				},
@@ -129,7 +129,7 @@ var _ = Describe("FilterGlob", Ordered, func() {
 				message:      "universal(any scope): glob filter (negate)",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeAny,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   6,
 					folders: 8,
 				},
@@ -145,7 +145,7 @@ var _ = Describe("FilterGlob", Ordered, func() {
 				message:      "universal(undefined scope): glob filter",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeAny,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   8,
 					folders: 0,
 				},
@@ -161,7 +161,7 @@ var _ = Describe("FilterGlob", Ordered, func() {
 				message:      "universal(any scope): glob filter (ifNotApplicable=true)",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeAny,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   8,
 					folders: 4,
 				},
@@ -178,7 +178,7 @@ var _ = Describe("FilterGlob", Ordered, func() {
 				message:      "universal(leaf scope): glob filter (ifNotApplicable=false)",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeAny,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   8,
 					folders: 0,
 				},
@@ -272,7 +272,7 @@ var _ = Describe("FilterGlob", Ordered, func() {
 				message:      "folder(with files): glob filter",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFoldersWithFiles,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 8,
 					children: map[string]int{
@@ -292,7 +292,7 @@ var _ = Describe("FilterGlob", Ordered, func() {
 				message:      "folder(with files): glob filter (negate)",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFoldersWithFiles,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 8,
 					children: map[string]int{

--- a/xfs/nav/filter-regex_test.go
+++ b/xfs/nav/filter-regex_test.go
@@ -112,7 +112,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "files(any scope): regex filter",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFiles,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   4,
 					folders: 0,
 				},
@@ -126,7 +126,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "files(any scope): regex filter (negate)",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFiles,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   10,
 					folders: 0,
 				},
@@ -141,7 +141,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "files(default to any scope): regex filter",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFiles,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   4,
 					folders: 0,
 				},
@@ -157,7 +157,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "folders(any scope): regex filter",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFolders,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 2,
 				},
@@ -172,7 +172,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "folders(any scope): regex filter (negate)",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFolders,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 6,
 				},
@@ -188,7 +188,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "folders(undefined scope): regex filter",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFolders,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 2,
 				},
@@ -204,7 +204,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "folders(top): regex filter (ifNotApplicable=true)",
 				relative:     "PROGRESSIVE-HOUSE",
 				subscription: nav.SubscribeFolders,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 10,
 				},
@@ -222,7 +222,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				relative:     "",
 				subscription: nav.SubscribeFolders,
 				mandatory:    []string{"PROGRESSIVE-HOUSE"},
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 1,
 				},
@@ -320,7 +320,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFoldersWithFiles,
 
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 8,
 					children: map[string]int{
@@ -340,7 +340,7 @@ var _ = Describe("FilterRegex", Ordered, func() {
 				message:      "folder(with files): regex filter (negate)",
 				relative:     "RETRO-WAVE",
 				subscription: nav.SubscribeFoldersWithFiles,
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 8,
 					children: map[string]int{

--- a/xfs/nav/helpers_test.go
+++ b/xfs/nav/helpers_test.go
@@ -23,7 +23,7 @@ type recordingMap map[string]int
 type recordingScopeMap map[string]nav.FilterScopeBiEnum
 type recordingOrderMap map[string]int
 
-type expectedNo struct {
+type directoryQuantities struct {
 	files    uint
 	folders  uint
 	children map[string]int
@@ -31,6 +31,7 @@ type expectedNo struct {
 
 type naviTE struct {
 	message       string
+	should        string
 	relative      string
 	extended      bool
 	once          bool
@@ -40,16 +41,22 @@ type naviTE struct {
 	callback      *nav.LabelledTraverseCallback
 	mandatory     []string
 	prohibited    []string
-	expectedNoOf  expectedNo
+	expectedNoOf  directoryQuantities
 }
 
 type skipTE struct {
 	naviTE
-	skipAt      string
-	prohibit    string
-	all         bool
-	folderCount int
-	fileCount   int
+	skipAt       string
+	prohibit     string
+	all          bool
+	expectedNoOf directoryQuantities
+}
+
+type sampleTE struct {
+	naviTE
+	filter    *filterTE
+	noOf      nav.SampleNoOf
+	useLastFn bool
 }
 
 type listenTE struct {
@@ -211,7 +218,7 @@ func foldersCallback(name string, extended bool) *nav.LabelledTraverseCallback {
 				"---> ☀️ FOLDERS//%v-CALLBACK%v: (depth:%v, children:%v) '%v'\n",
 				name, ex, depth, actualNoChildren, item.Path,
 			)
-			Expect(item.Info.IsDir()).To(BeTrue())
+			Expect(item.IsDir()).To(BeTrue())
 
 			if extended {
 				Expect(item.Extension).NotTo(BeNil(), helpers.Reason(item.Path))
@@ -231,7 +238,7 @@ func filesCallback(name string, extended bool) *nav.LabelledTraverseCallback {
 		Label: "files callback",
 		Fn: func(item *nav.TraverseItem) error {
 			GinkgoWriter.Printf("---> 🌙 FILES//%v-CALLBACK%v: '%v'\n", name, ex, item.Path)
-			Expect(item.Info.IsDir()).To(BeFalse())
+			Expect(item.IsDir()).To(BeFalse())
 
 			if extended {
 				Expect(item.Extension).NotTo(BeNil(), helpers.Reason(item.Path))
@@ -264,7 +271,7 @@ func foldersScopeCallback(name string) *nav.LabelledTraverseCallback {
 				name, item.Extension.NodeScope, item.Extension.Name,
 			)
 			Expect(item.Extension).NotTo(BeNil(), helpers.Reason(item.Extension.Name))
-			Expect(item.Info.IsDir()).To(BeTrue())
+			Expect(item.IsDir()).To(BeTrue())
 			return nil
 		},
 	}
@@ -278,7 +285,7 @@ func filesScopeCallback(name string) *nav.LabelledTraverseCallback {
 				name, item.Extension.NodeScope, item.Extension.Name,
 			)
 			Expect(item.Extension).NotTo(BeNil(), helpers.Reason(item.Extension.Name))
-			Expect(item.Info.IsDir()).To(BeFalse())
+			Expect(item.IsDir()).To(BeFalse())
 			return nil
 		},
 	}
@@ -307,7 +314,7 @@ func foldersSortCallback(name string) *nav.LabelledTraverseCallback {
 				name, item.Extension.Name,
 			)
 			Expect(item.Extension).NotTo(BeNil(), helpers.Reason(item.Extension.Name))
-			Expect(item.Info.IsDir()).To(BeTrue())
+			Expect(item.IsDir()).To(BeTrue())
 			return nil
 		},
 	}
@@ -321,7 +328,7 @@ func filesSortCallback(name string) *nav.LabelledTraverseCallback {
 				name, item.Extension.Name,
 			)
 			Expect(item.Extension).NotTo(BeNil(), helpers.Reason(item.Extension.Name))
-			Expect(item.Info.IsDir()).To(BeFalse())
+			Expect(item.IsDir()).To(BeFalse())
 			return nil
 		},
 	}
@@ -351,7 +358,7 @@ func foldersCaseSensitiveCallback(first, second string) *nav.LabelledTraverseCal
 			recording[item.Path] = len(item.Children)
 
 			GinkgoWriter.Printf("---> ☀️ CASE-SENSITIVE-CALLBACK: '%v'\n", item.Path)
-			Expect(item.Info.IsDir()).To(BeTrue())
+			Expect(item.IsDir()).To(BeTrue())
 
 			if strings.HasSuffix(item.Path, second) {
 				GinkgoWriter.Printf("---> 💧 FIRST: '%v', 💧 SECOND: '%v'\n", first, second)

--- a/xfs/nav/navigation-agent.go
+++ b/xfs/nav/navigation-agent.go
@@ -89,7 +89,7 @@ func (a *navigationAgent) read(
 	de := deFactory.new(&directoryEntriesFactoryParams{
 		o:       a.o,
 		order:   order,
-		entries: &entries,
+		entries: entries,
 	})
 
 	return de, err
@@ -106,8 +106,6 @@ func (a *navigationAgent) notify(params *agentNotifyParams) (SkipTraversal, erro
 	skip := SkipTraversalNoneEn
 
 	if params.readErr != nil {
-		// TODO: this needs a re-write so that it can also handle SkipTraversalDirEn
-		//
 		if a.doInvoke.Get() {
 			item2 := params.item.clone()
 			item2.Error = xi18n.NewThirdPartyErr(params.readErr)

--- a/xfs/nav/navigator-files.go
+++ b/xfs/nav/navigator-files.go
@@ -35,9 +35,10 @@ func (n *filesNavigator) traverse(params *traverseParams) (*TraverseItem, error)
 	var (
 		entries *DirectoryEntries
 		readErr error
+		isDir   = params.item.IsDir()
 	)
 
-	if params.item.Info.IsDir() {
+	if isDir {
 		entries, readErr = n.agent.read(
 			params.item.Path,
 			n.o.Store.Behaviours.Sort.DirectoryEntryOrder,
@@ -46,19 +47,21 @@ func (n *filesNavigator) traverse(params *traverseParams) (*TraverseItem, error)
 		// Files and Folders need to be sorted independently to preserve the navigation order
 		// stipulated by .Behaviours.Sort.DirectoryEntryOrder
 		//
-		entries.sort(&entries.Files)
-		entries.sort(&entries.Folders)
+		entries.sort(entries.Files)
+		entries.sort(entries.Folders)
 	} else {
 		entries = &DirectoryEntries{}
 	}
 
-	if (params.item.Info != nil) && !(params.item.Info.IsDir()) {
+	if !isDir {
 		n.o.Hooks.Extend(navi, entries)
 
 		// Effectively, this is the file only filter
 		//
 		return nil, params.frame.proxy(params.item, nil)
 	}
+
+	// sample here
 
 	sorted := entries.all()
 

--- a/xfs/nav/navigator-folders.go
+++ b/xfs/nav/navigator-folders.go
@@ -44,7 +44,7 @@ func (n *foldersNavigator) traverse(params *traverseParams) (*TraverseItem, erro
 		DirectoryEntryOrderFoldersFirstEn,
 	)
 	folders := entries.Folders
-	entries.sort(&folders) // !!!!
+	entries.sort(folders) // !!!!
 
 	if n.o.Store.Subscription == SubscribeFoldersWithFiles {
 		var files []fs.DirEntry
@@ -67,11 +67,13 @@ func (n *foldersNavigator) traverse(params *traverseParams) (*TraverseItem, erro
 			filteredOut: uint(allFilesCount - filteredIn),
 		}
 
-		entries.sort(&files)
+		entries.sort(files)
 		params.item.Children = files
 	}
 
 	n.o.Hooks.Extend(navi, entries)
+
+	// sample here
 
 	if le := params.frame.proxy(params.item, compoundCounts); le != nil {
 		return nil, le

--- a/xfs/nav/navigator-universal.go
+++ b/xfs/nav/navigator-universal.go
@@ -31,9 +31,10 @@ func (n *universalNavigator) traverse(params *traverseParams) (*TraverseItem, er
 	var (
 		entries *DirectoryEntries
 		readErr error
+		isDir   = params.item.IsDir()
 	)
 
-	if params.item.Info.IsDir() {
+	if isDir {
 		entries, readErr = n.agent.read(
 			params.item.Path,
 			n.o.Store.Behaviours.Sort.DirectoryEntryOrder,
@@ -42,14 +43,16 @@ func (n *universalNavigator) traverse(params *traverseParams) (*TraverseItem, er
 		// Files and Folders need to be sorted independently to preserve the navigation order
 		// stipulated by .Behaviours.Sort.DirectoryEntryOrder
 		//
-		entries.sort(&entries.Files)
-		entries.sort(&entries.Folders)
+		entries.sort(entries.Files)
+		entries.sort(entries.Folders)
 	} else {
 		entries = &DirectoryEntries{}
 	}
 
 	sorted := entries.all()
 	n.o.Hooks.Extend(navi, entries)
+
+	// sample here
 
 	if le := params.frame.proxy(params.item, nil); le != nil {
 		return nil, le

--- a/xfs/nav/new-navigator.go
+++ b/xfs/nav/new-navigator.go
@@ -84,6 +84,8 @@ func (f navigatorImplFactory) new(o *TraverseOptions) navigatorImpl {
 				log:   logger,
 			},
 		}
+	default:
+		panic(ErrUndefinedSubscriptionType)
 	}
 
 	return impl

--- a/xfs/nav/resume-strategy-spawn.go
+++ b/xfs/nav/resume-strategy-spawn.go
@@ -60,8 +60,8 @@ func (s *spawnStrategy) conclude(conclusion *concludeInfo) (*TraverseResult, err
 		inclusive: conclusion.inclusive,
 	})
 
-	following.siblings.sort(&following.siblings.Files)
-	following.siblings.sort(&following.siblings.Folders)
+	following.siblings.sort(following.siblings.Files)
+	following.siblings.sort(following.siblings.Folders)
 
 	compoundResult, err := s.seed(&seedParams{
 		frame:      s.nc.frame,
@@ -144,7 +144,7 @@ func (s *spawnStrategy) following(params *followingParams) *shard {
 		&directoryEntriesFactoryParams{
 			o:       s.o,
 			order:   params.order,
-			entries: &siblings,
+			entries: siblings,
 		},
 	)
 

--- a/xfs/nav/traverse-defs.go
+++ b/xfs/nav/traverse-defs.go
@@ -188,3 +188,6 @@ const (
 	SkipTraversalDirEn
 	SkipTraversalAllEn
 )
+
+// SampleCallback
+type SampleCallback func(entries *DirectoryEntries) *DirectoryEntries

--- a/xfs/nav/traverse-navigator-skip_test.go
+++ b/xfs/nav/traverse-navigator-skip_test.go
@@ -50,12 +50,12 @@ var _ = Describe("TraverseNavigatorSkip", Ordered, func() {
 			folders := result.Metrics.Count(nav.MetricNoFoldersInvokedEn)
 			GinkgoWriter.Printf("===> files: '%v', folders: '%v'\n", files, folders)
 
-			if entry.folderCount > 0 {
-				Expect(folders).To(BeEquivalentTo(entry.folderCount))
+			if entry.expectedNoOf.folders > 0 {
+				Expect(folders).To(BeEquivalentTo(entry.expectedNoOf.folders))
 			}
 
-			if entry.fileCount > 0 {
-				Expect(files).To(BeEquivalentTo(entry.fileCount))
+			if entry.expectedNoOf.files > 0 {
+				Expect(files).To(BeEquivalentTo(entry.expectedNoOf.files))
 			}
 		},
 		func(entry *skipTE) string {
@@ -66,80 +66,96 @@ var _ = Describe("TraverseNavigatorSkip", Ordered, func() {
 				message:      "universal: SkipAll (skipAt:folder)",
 				subscription: nav.SubscribeAny,
 			},
-			skipAt:      "College",
-			prohibit:    "Northern Council",
-			all:         true,
-			fileCount:   4,
-			folderCount: 4,
+			skipAt:   "College",
+			prohibit: "Northern Council",
+			all:      true,
+			expectedNoOf: directoryQuantities{
+				files:   4,
+				folders: 4,
+			},
 		}),
 		Entry(nil, &skipTE{
 			naviTE: naviTE{
 				message:      "universal: SkipDir (skipAt:folder)",
 				subscription: nav.SubscribeAny,
 			},
-			skipAt:      "College",
-			prohibit:    "Northern Council",
-			fileCount:   4,
-			folderCount: 4,
+			skipAt:   "College",
+			prohibit: "Northern Council",
+			expectedNoOf: directoryQuantities{
+				files:   4,
+				folders: 4,
+			},
 		}),
 		Entry(nil, &skipTE{
 			naviTE: naviTE{
 				message:      "universal: SkipAll (skipAt:file)",
 				subscription: nav.SubscribeAny,
 			},
-			skipAt:      "A1 - The Telephone Call.flac",
-			prohibit:    "A2 - Night Drive.flac",
-			all:         true,
-			fileCount:   1,
-			folderCount: 3,
+			skipAt:   "A1 - The Telephone Call.flac",
+			prohibit: "A2 - Night Drive.flac",
+			all:      true,
+			expectedNoOf: directoryQuantities{
+				files:   1,
+				folders: 3,
+			},
 		}),
 		Entry(nil, &skipTE{
 			naviTE: naviTE{
 				message:      "universal: SkipDir (skipAt:file)",
 				subscription: nav.SubscribeAny,
 			},
-			skipAt:      "A1 - The Telephone Call.flac",
-			prohibit:    "A2 - Night Drive.flac",
-			fileCount:   11,
-			folderCount: 8,
+			skipAt:   "A1 - The Telephone Call.flac",
+			prohibit: "A2 - Night Drive.flac",
+			expectedNoOf: directoryQuantities{
+				files:   11,
+				folders: 8,
+			},
 		}),
 		Entry(nil, &skipTE{
 			naviTE: naviTE{
 				message:      "folders: SkipAll (skipAt:folder)",
 				subscription: nav.SubscribeFolders,
 			},
-			skipAt:      "College",
-			prohibit:    "Northern Council",
-			all:         true,
-			folderCount: 4,
+			skipAt:   "College",
+			prohibit: "Northern Council",
+			all:      true,
+			expectedNoOf: directoryQuantities{
+				folders: 4,
+			},
 		}),
 		Entry(nil, &skipTE{
 			naviTE: naviTE{
 				message:      "folders: SkipDir (skipAt:folder)",
 				subscription: nav.SubscribeFolders,
 			},
-			skipAt:      "Northern Council",
-			prohibit:    "Teenage Color",
-			folderCount: 7,
+			skipAt:   "Northern Council",
+			prohibit: "Teenage Color",
+			expectedNoOf: directoryQuantities{
+				folders: 7,
+			},
 		}),
 		Entry(nil, &skipTE{
 			naviTE: naviTE{
 				message:      "files: SkipAll (skipAt:file)",
 				subscription: nav.SubscribeFiles,
 			},
-			skipAt:    "A1 - The Telephone Call.flac",
-			prohibit:  "A2 - Night Drive.flac",
-			all:       true,
-			fileCount: 1,
+			skipAt:   "A1 - The Telephone Call.flac",
+			prohibit: "A2 - Night Drive.flac",
+			all:      true,
+			expectedNoOf: directoryQuantities{
+				files: 1,
+			},
 		}),
 		Entry(nil, &skipTE{
 			naviTE: naviTE{
 				message:      "files: SkipDir (skipAt:file)",
 				subscription: nav.SubscribeFiles,
 			},
-			skipAt:    "A1 - The Telephone Call.flac",
-			prohibit:  "A2 - Night Drive.flac",
-			fileCount: 11,
+			skipAt:   "A1 - The Telephone Call.flac",
+			prohibit: "A2 - Night Drive.flac",
+			expectedNoOf: directoryQuantities{
+				files: 11,
+			},
 		}),
 	)
 })

--- a/xfs/nav/traverse-navigator_test.go
+++ b/xfs/nav/traverse-navigator_test.go
@@ -108,7 +108,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     IsExtended,
 				subscription: nav.SubscribeAny,
 				callback:     universalCallback("LEAF-PATH", IsExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   4,
 					folders: 1,
 				},
@@ -119,7 +119,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     NotExtended,
 				subscription: nav.SubscribeAny,
 				callback:     universalCallback("CONTAINS-FOLDERS", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   14,
 					folders: 8,
 				},
@@ -131,7 +131,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				visit:        true,
 				subscription: nav.SubscribeAny,
 				callback:     universalCallback("VISIT-CONTAINS-FOLDERS", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   14,
 					folders: 8,
 				},
@@ -142,7 +142,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     NotExtended,
 				subscription: nav.SubscribeAny,
 				callback:     universalCallback("CONTAINS-FOLDERS (large)", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   656,
 					folders: 178,
 				},
@@ -154,7 +154,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				once:         true,
 				subscription: nav.SubscribeAny,
 				callback:     universalCallback("CONTAINS-FOLDERS (large, ensure single invoke)", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   656,
 					folders: 178,
 				},
@@ -168,7 +168,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     NotExtended,
 				subscription: nav.SubscribeFolders,
 				callback:     foldersCallback("LEAF-PATH", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 1,
 				},
@@ -179,7 +179,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     IsExtended,
 				subscription: nav.SubscribeFolders,
 				callback:     foldersCallback("CONTAINS-FOLDERS ", IsExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 8,
 				},
@@ -191,7 +191,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				visit:        true,
 				subscription: nav.SubscribeFolders,
 				callback:     foldersCallback("CONTAINS-FOLDERS (check all invoked)", IsExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 8,
 				},
@@ -202,7 +202,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     NotExtended,
 				subscription: nav.SubscribeFolders,
 				callback:     foldersCallback("CONTAINS-FOLDERS (large)", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 178,
 				},
@@ -214,7 +214,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				once:         true,
 				subscription: nav.SubscribeFolders,
 				callback:     foldersCallback("CONTAINS-FOLDERS (large, ensure single invoke)", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 178,
 				},
@@ -226,7 +226,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				subscription:  nav.SubscribeFolders,
 				caseSensitive: true,
 				callback:      foldersCaseSensitiveCallback("rock/metal/HARD-METAL", "rock/metal/dark"),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   0,
 					folders: 41,
 				},
@@ -240,7 +240,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     NotExtended,
 				subscription: nav.SubscribeFiles,
 				callback:     filesCallback("LEAF-PATH", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   4,
 					folders: 0,
 				},
@@ -251,7 +251,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     NotExtended,
 				subscription: nav.SubscribeFiles,
 				callback:     filesCallback("CONTAINS-FOLDERS", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   14,
 					folders: 0,
 				},
@@ -263,7 +263,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				visit:        true,
 				subscription: nav.SubscribeFiles,
 				callback:     filesCallback("VISIT-CONTAINS-FOLDERS", NotExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   14,
 					folders: 0,
 				},
@@ -274,7 +274,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				extended:     IsExtended,
 				subscription: nav.SubscribeFiles,
 				callback:     filesCallback("CONTAINS-FOLDERS (large)", IsExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   656,
 					folders: 0,
 				},
@@ -286,7 +286,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 				once:         true,
 				subscription: nav.SubscribeFiles,
 				callback:     filesCallback("CONTAINS-FOLDERS (large, ensure single invoke)", IsExtended),
-				expectedNoOf: expectedNo{
+				expectedNoOf: directoryQuantities{
 					files:   656,
 					folders: 0,
 				},
@@ -375,7 +375,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 			extended:     IsExtended,
 			subscription: nav.SubscribeFoldersWithFiles,
 			callback:     foldersCallback("LEAF-PATH", IsExtended),
-			expectedNoOf: expectedNo{
+			expectedNoOf: directoryQuantities{
 				files:   0,
 				folders: 1,
 				children: map[string]int{
@@ -390,7 +390,7 @@ var _ = Describe("TraverseNavigator(logged)", Ordered, func() {
 			extended:     IsExtended,
 			visit:        true,
 			subscription: nav.SubscribeFoldersWithFiles,
-			expectedNoOf: expectedNo{
+			expectedNoOf: directoryQuantities{
 				files:   0,
 				folders: 8,
 				children: map[string]int{

--- a/xfs/nav/traverse-sample_test.go
+++ b/xfs/nav/traverse-sample_test.go
@@ -1,0 +1,197 @@
+package nav_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/snivilised/extendio/i18n"
+	"github.com/snivilised/extendio/internal/helpers"
+
+	"github.com/snivilised/extendio/xfs/nav"
+)
+
+/*
+  ---> 🛡️ [traverse-navigator-test:BEGIN], root: '&{false /Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE}'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Chromatics'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Chromatics/Night Drive'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Chromatics/Night Drive/A1 - The Telephone Call.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Chromatics/Night Drive/A2 - Night Drive.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Chromatics/Night Drive/cover.night-drive.jpg'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Chromatics/Night Drive/vinyl-info.night-drive.txt'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Northern Council'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Northern Council/A1 - Incident.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Northern Council/A2 - The Zemlya Expedition.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Northern Council/cover.northern-council.jpg'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Northern Council/vinyl-info.northern-council.txt'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Teenage Color'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Teenage Color/A1 - Can You Kiss Me First.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Teenage Color/A2 - Teenage Color.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/College/Teenage Color/vinyl-info.teenage-color.txt'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Electric Youth'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Electric Youth/Innerworld'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Electric Youth/Innerworld/A1 - Before Life.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Electric Youth/Innerworld/A2 - Runaway.flac'
+  ---> 🌊 UNIVERSAL//CONTAINS-FOLDERS-CALLBACK: (depth:9999) '/Users/plastikfan/dev/github/snivilised/extendio/Test/data/MUSICO/RETRO-WAVE/Electric Youth/Innerworld/vinyl-info.innerworld.txt'
+*/
+
+var _ = XDescribe("Traverse With Sample", Ordered, func() {
+	var root string
+
+	BeforeAll(func() {
+		root = musico()
+	})
+
+	BeforeEach(func() {
+		if err := Use(func(o *UseOptions) {
+			o.Tag = DefaultLanguage.Get()
+		}); err != nil {
+			Fail(err.Error())
+		}
+	})
+
+	DescribeTable("sample",
+		func(entry *sampleTE) {
+			path := helpers.Path(root, "RETRO-WAVE")
+			providedOptions := nav.GetDefaultOptions()
+			providedOptions.Store.Subscription = entry.subscription
+			providedOptions.Store.DoExtend = true
+			providedOptions.Callback = &nav.LabelledTraverseCallback{
+				Label: "test universal callback",
+				Fn: func(item *nav.TraverseItem) error {
+					GinkgoWriter.Printf(
+						"---> 🌊 SAMPLE-CALLBACK: '%v'\n", item.Path,
+					)
+
+					prohibited := fmt.Sprintf("%v, was invoked, but does not satisfy sample criteria",
+						helpers.Reason(item.Extension.Name),
+					)
+					Expect(entry.prohibited).ToNot(ContainElement(item.Extension.Name), prohibited)
+
+					return nil
+				},
+			}
+			providedOptions.Notify.OnBegin = begin("🛡️")
+			providedOptions.Store.Sampling.NoOf = entry.noOf
+
+			if entry.useLastFn {
+				providedOptions.Sampler.Fn = nav.GetLastSampler(&entry.noOf)
+			}
+
+			if entry.filter != nil {
+				filterDefs := &nav.FilterDefinitions{
+					Children: nav.CompoundFilterDef{
+						Type:        nav.FilterTypeGlobEn,
+						Description: entry.filter.name,
+						Pattern:     entry.filter.pattern,
+						Negate:      entry.filter.negate,
+					},
+				}
+				providedOptions.Store.FilterDefs = filterDefs
+			}
+
+			_, _ = nav.New().Primary(&nav.Prime{
+				Path:            path,
+				ProvidedOptions: providedOptions,
+			}).Run()
+
+			Expect(1)
+		},
+		func(entry *sampleTE) string {
+			return fmt.Sprintf("🧪 ===> given: '%v', should: '%v'", entry.message, entry.should)
+		},
+
+		Entry(nil, &sampleTE{
+			naviTE: naviTE{
+				message:      "universal: default (top), with 2 files",
+				should:       "invoke for at most 2 files per directory",
+				subscription: nav.SubscribeAny,
+				prohibited:   []string{"cover.night-drive.jpg"},
+			},
+			noOf: nav.SampleNoOf{
+				Files: 2,
+			},
+		}),
+
+		Entry(nil, &sampleTE{
+			naviTE: naviTE{
+				message:      "universal: default (top), with 2 folders",
+				should:       "invoke for at most 2 folders per directory",
+				subscription: nav.SubscribeAny,
+				prohibited:   []string{"Electric Youth"},
+			},
+			noOf: nav.SampleNoOf{
+				Folders: 2,
+			},
+		}),
+
+		Entry(nil, &sampleTE{
+			naviTE: naviTE{
+				message:      "universal: default (top), with 2 files and 2 folders",
+				should:       "invoke for at most 2 files and 2 folders per directory",
+				subscription: nav.SubscribeAny,
+				prohibited:   []string{"cover.night-drive.jpg", "Electric Youth"},
+			},
+			noOf: nav.SampleNoOf{
+				Files:   2,
+				Folders: 2,
+			},
+		}),
+
+		Entry(nil, &sampleTE{
+			naviTE: naviTE{
+				message:      "folders: default (top), with 2 folders",
+				should:       "invoke for at most 2 folders per directory",
+				subscription: nav.SubscribeFolders,
+				prohibited:   []string{"Electric Youth"},
+			},
+			noOf: nav.SampleNoOf{
+				Folders: 2,
+			},
+		}),
+
+		Entry(nil, &sampleTE{
+			naviTE: naviTE{
+				message:      "folders: custom, with last single folder",
+				should:       "invoke for only last folder per directory",
+				subscription: nav.SubscribeFolders,
+				prohibited:   []string{"Chromatics"},
+			},
+			useLastFn: true,
+			noOf: nav.SampleNoOf{
+				Folders: 1,
+			},
+		}),
+
+		// TODO: With filter for folders: first Co* folder (College)
+
+		Entry(nil, &sampleTE{
+			naviTE: naviTE{
+				message:      "files: default (top), with 2 files",
+				should:       "invoke for at most 2 files per directory",
+				subscription: nav.SubscribeFolders,
+				prohibited:   []string{"cover.night-drive.jpg"},
+			},
+			noOf: nav.SampleNoOf{
+				Files: 2,
+			},
+		}),
+
+		Entry(nil, &sampleTE{
+			naviTE: naviTE{
+				message:      "files: custom, with last single file",
+				should:       "invoke for only last file per directory",
+				subscription: nav.SubscribeFiles,
+				prohibited:   []string{"A1 - The Telephone Call.flac"},
+			},
+			useLastFn: true,
+			noOf: nav.SampleNoOf{
+				Folders: 1,
+			},
+		}),
+
+		// TODO: With filter for files: first cover* file
+	)
+})

--- a/xfs/nav/traverse-samplers.go
+++ b/xfs/nav/traverse-samplers.go
@@ -1,0 +1,69 @@
+package nav
+
+import (
+	"io/fs"
+
+	"github.com/samber/lo"
+)
+
+type subSetFn func(entries []fs.DirEntry, n int) []fs.DirEntry
+
+func firstSampler(entries []fs.DirEntry, n int) []fs.DirEntry {
+	return entries[:len(entries)-(min(n, len(entries)))]
+}
+
+func lastSampler(entries []fs.DirEntry, n int) []fs.DirEntry {
+	return entries[len(entries)-(min(n, len(entries))):]
+}
+
+func getSubSetSampler(noOf *SampleNoOf, fn subSetFn) SampleCallback {
+	return func(entries *DirectoryEntries) *DirectoryEntries {
+		o := entries.Options
+		clone := entries.Sample()
+
+		switch o.Store.Subscription {
+		case SubscribeAny:
+			clone.Folders = lo.Ternary(noOf.Folders > 0,
+				fn(entries.Folders, int(noOf.Folders)),
+				entries.Folders,
+			)
+
+			clone.Files = lo.Ternary(noOf.Files > 0,
+				fn(entries.Files, int(noOf.Files)),
+				entries.Files,
+			)
+
+		case SubscribeFolders:
+		case SubscribeFoldersWithFiles:
+			clone.Folders = fn(entries.Folders, int(noOf.Folders))
+		case SubscribeFiles:
+			clone.Files = fn(entries.Files, int(noOf.Files))
+
+		default:
+		}
+
+		return clone
+	}
+}
+
+// GetFirstSampler obtains a sampler function which gets the first
+// n entries of a directory, where n is either the number of files
+// or folders which is determined by the subscription type.
+// To use the sampler feature, the client will find they will need to
+// use the options push model so that the SampleNoOf instance required
+// can be provided. The push model requires the use of ProvidedOptions
+// instead of using the pull model via OptionsFn callback.
+func GetFirstSampler(noOf *SampleNoOf) SampleCallback {
+	return getSubSetSampler(noOf, firstSampler)
+}
+
+// GetLastSampler obtains a sampler function which gets the last
+// n entries of a directory, where n is either the number of files
+// or folders which is determined by the subscription type.
+// To use the sampler feature, the client will find they will need to
+// use the options push model so that the SampleNoOf instance required
+// can be provided. The push model requires the use of ProvidedOptions
+// instead of using the pull model via OptionsFn callback.
+func GetLastSampler(noOf *SampleNoOf) SampleCallback {
+	return getSubSetSampler(noOf, lastSampler)
+}


### PR DESCRIPTION
fix(nav): remove incorrect use of pointer to slice in sort (#366)

ref(nav): use item.IsDir (#366)

ref(nav): fix more pointer to slices (#366)

test(nav): use expectedNo struct in skip tests (#366)

ref(nav): rename expectedNo to directoryQuantities (#366)

ref(nav): panic if subscription type not set (#366)

ref(nav): add benign node filter for compound only filtering (#366)

ref(nav): add isFilteringActive (#366)

ref(nav): simplify useExtendHook (#366)

ref(nav): streamline filter init and automatically apply benigh filter (#366)

feat(nav): setup sample failing tests and other sample support (#366)